### PR TITLE
fix csh installation with conda

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,3 @@
-
+1.0.10 - fix csh/tcsh installations
 19-December-2019 - First version of the scipion installer
 

--- a/scipioninstaller/__init__.py
+++ b/scipioninstaller/__init__.py
@@ -1,2 +1,2 @@
 INSTALL_ENTRY = 'installscipion'
-__version__ = '1.0.9'
+__version__ = '1.0.10'

--- a/scipioninstaller/installer.py
+++ b/scipioninstaller/installer.py
@@ -62,11 +62,18 @@ def getCondaCmd(scipionEnv, noAsk):
 
 def getCondaInitCmd():
     shell = os.path.basename(os.environ.get("SHELL", "bash"))
-    return 'eval "$(%s shell.%s hook)"' % (checkProgram(CONDA), shell)
+    if shell in ["csh", "tcsh"]:
+        return 'set cinit="`%s shell.%s hook`" && eval "$cinit"' % (checkProgram(CONDA), shell)
+    else:
+        return 'eval "$(%s shell.%s hook)"' % (checkProgram(CONDA), shell)
 
 
 def getCondaenvActivationCmd(scipionEnv):
-    return "conda activate %s" % scipionEnv
+    shell = os.path.basename(os.environ.get("SHELL", "bash"))
+    if shell in ["csh", "tcsh"]:
+        return 'set cact="`%s shell.%s activate %s`" && eval "$cact"' % (checkProgram(CONDA), shell, scipionEnv)
+    else:
+        return "conda activate %s" % scipionEnv
 
 
 def cmdfy(cmd, sep=CMD_SEP):


### PR DESCRIPTION
After a few hours I was able to install scipion via miniconda in a user account with tcsh as default shell. The problem with csh that conda functions are not exported to the subshells (in our case /bin/sh invoked by os.system). See https://github.com/conda/conda/issues/7980

This closes #19 

Other csh issues like Illegal variable or syntax error were fixed since conda 4.7.x